### PR TITLE
Send a dispatch to visidata whenever a version tag is added

### DIFF
--- a/.github/workflows/visidata.yml
+++ b/.github/workflows/visidata.yml
@@ -1,0 +1,20 @@
+name: update-visidata
+on:
+  create:
+
+jobs:
+  update:
+    # runs on version tag creation
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Send VisiData a Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: saulpw/visidata
+          event-type: unzip-http
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
This has not been tested (I want to test with dummy repos). We would need to set up the access tokens before it works. I believe the access token that it needs is VisiData's.

Uses: https://github.com/peter-evans/repository-dispatch