### PR TITLE
fix: download small zip error

### DIFF
--- a/unzip_http.py
+++ b/unzip_http.py
@@ -129,7 +129,10 @@ class RemoteZipFile:
             warning(f"{hostname} Accept-Ranges header ('{r}') is not 'bytes'--trying anyway")
 
         self.zip_size = int(resp.headers['Content-Length'])
-        resp = self.get_range(self.zip_size-65536, 65536)
+        resp = self.get_range(
+            max(self.zip_size-65536, 0),
+            65536
+        )
 
         cdir_start = -1
         i = resp.data.rfind(self.magic_eocd64)
@@ -146,7 +149,10 @@ class RemoteZipFile:
         if cdir_start < 0 or cdir_start >= self.zip_size:
             error('cannot find central directory')
 
-        filehdr_index = 65536 - (self.zip_size - cdir_start)
+        if self.zip_size <= 65536:
+            filehdr_index = cdir_start
+        else:
+            filehdr_index = 65536 - (self.zip_size - cdir_start)
 
         if filehdr_index < 0:
             resp = self.get_range(cdir_start, self.zip_size - cdir_start)


### PR DESCRIPTION
When you tried to download a small zip file, you encountered the following error. This PR fix it.
```
Traceback (most recent call last):
  File "/home/horw/PycharmProjects/unzip-http/unzip-http", line 122, in <module>
    main(args)
  File "/home/horw/PycharmProjects/unzip-http/unzip-http", line 103, in main
    for f in rzf.infolist():
  File "/home/horw/PycharmProjects/unzip-http/unzip_http.py", line 119, in infolist
    return list(self.infoiter())
  File "/home/horw/PycharmProjects/unzip-http/unzip_http.py", line 147, in infoiter
    error('cannot find central directory')
  File "/home/horw/PycharmProjects/unzip-http/unzip_http.py", line 35, in error
    raise Exception(s)
Exception: cannot find central directory
```
Test file:
[hello.zip](https://github.com/saulpw/unzip-http/files/13190697/hello.zip)
