### PR TITLE
Fix README typo: remove duplicate phrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Note: HTTP server must send `Accept-Ranges: bytes` and `Content-Length` in heade
 Options:
 
 - `-l`: List files in remote .zip file (default if no filenames given)
-- `-f`: Recreate folder structure from .zip file when extracting (instead of extracting files to the current directly to the current directory)
+- `-f`: Recreate folder structure from .zip file when extracting (instead of extracting files to the current directory)
 - `-o`: Write files to stdout (if multiple files, concatenate them in zipfile order)
 
 # Python module `unzip_http`


### PR DESCRIPTION
This PR fixes a typo in the README where the phrase "to the current" is accidentally duplicated in the description of the `-f` flag:

**Before:**
"instead of extracting files to the current directly to the current directory"

**After:**
"instead of extracting files to the current directory"

This improves the readability of the usage documentation.